### PR TITLE
Resolve issues with Ansible 2.8 TaskInclude.

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,6 +1,7 @@
 ---
-- name: '[Debian] Include Dependencies installation tasks'
-  include_tasks: dependencies.yml
+- block:
+  - name: '[Debian] Include Dependencies installation tasks'
+    include_tasks: dependencies.yml
   become: yes
   tags:
     - nerdfonts


### PR DESCRIPTION
```
    TASK [drew-kun.nerdfonts : [main] Include Debian-specific tasks] *******************************************
    fatal: [xxx]: FAILED! => {"reason": "'become' is not a valid attribute for a TaskInclude\n\nThe error appears to be in 'xxx/drew-kun.nerdfonts/tasks/Debian.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: '[Debian] Include Dependencies installation tasks'\n  ^ here\n"}
```